### PR TITLE
Add rocm toolchain into fbcode

### DIFF
--- a/infra_macros/macro_lib/convert/cpp.py
+++ b/infra_macros/macro_lib/convert/cpp.py
@@ -172,6 +172,7 @@ class CppConverter(base.Converter):
             use_default_test_main=True,
             lib_name=None,
             nvcc_flags=(),
+            hip_flags=(),
             enable_lto=False,
             hs_profile=None,
             dont_link_prerequisites=None,
@@ -367,6 +368,11 @@ class CppConverter(base.Converter):
             src_and_dep_helpers.format_platform_param(
                 list(itertools.chain(
                     *[('-_NVCC_', flag) for flag in nvcc_flags]))))
+
+        out_lang_plat_compiler_flags.setdefault('hip_cpp_output', [])
+        out_lang_plat_compiler_flags['hip_cpp_output'].extend(
+            src_and_dep_helpers.format_platform_param(
+                hip_flags))
 
         clang_profile = native.read_config('cxx', 'profile')
         if clang_profile != None:
@@ -977,6 +983,7 @@ class CppConverter(base.Converter):
             'name',
             'nodefaultlibs',
             'nvcc_flags',
+            'hip_flags',
             'precompiled_header',
             'preprocessor_flags',
             'py3_sensitive_deps',


### PR DESCRIPTION
Summary:
Add ROCm toolchain into fbcode:
(1) add rocm into third-party2 and third-party-buck
(2) edit gen_mode.py to add HIP_FLAGS, HIP_RESOURCES that buck can use to compile hcc programs
(3) create a wrap_hcc.py wrapper to process HIP flags, and initiate calling hcc; also with misc changes to the tools/build to make buck happy

The buck diff D10443659 has already landed which can take the hip flags.

In order for easier merging, this diff doesn't contain the auto-generated files. The full commit needs to run the following steps:

  $ tp2_update_fbcode rocm
  $ python tools/build/buck/gen_modes.py;
  # generate the wrap_hip.par file
  $ buck build mode/opt tools/build:wrap_hip;
  $ cp ~/fbsource/fbcode/buck-out/gen/tools/build/wrap_hip.par tools/build/wrap_hip.par

The last step is currently temporary -- the ideal location will be `tools/build/bin`. We probably want to wait for `hip_wrap.py` a bit more stabilized before we move this to the fbpkg.

Reviewed By: andrewjcg

Differential Revision: D10442030
